### PR TITLE
Adapted package installation for new package name scheme

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@
 
 _instana:
   enable: no
+  package_type: static # static or dynamic
   install_environment:
     INSTANA_AGENT_KEY: "{{ S_INSTANA_AGENT_KEY }}"
     # INSTANA_AGENT_ENDPOINT:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   apt_repository: repo="deb [arch=amd64] https://_:{{ _instana.install_environment.INSTANA_AGENT_KEY }}@packages.instana.io/agent generic main" state=present
 
 - name: Install Instana Agent
-  apt: name="instana-agent-full" state=latest
+  apt: name="instana-agent-{{ _instana.package_type }}" state=latest
   environment: "{{ _instana.install_environment }}"
 
 - name: Generate Instana Agent Override Configuration


### PR DESCRIPTION
The Instana-Agent now ships in two different flavors: 'static' and
'dynamic'. The installation task has been changed to reflect this.

The package type to be installed can be configured through a new
variable: _instana.package_type.